### PR TITLE
Add rendering of multiple items depending on fullness

### DIFF
--- a/Forge/src/main/java/jackdaw/applecrates/AppleCrates.java
+++ b/Forge/src/main/java/jackdaw/applecrates/AppleCrates.java
@@ -1,10 +1,13 @@
 package jackdaw.applecrates;
 
+import jackdaw.applecrates.client.ClientConfig;
 import jackdaw.applecrates.api.AppleCrateAPI;
 import jackdaw.applecrates.api.GeneralRegistry;
 import jackdaw.applecrates.compat.SectionProtection;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,9 +24,10 @@ public class AppleCrates {
         if (ModList.get().isLoaded("sectionprotection"))
             SectionProtection.init();
 
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC, "apple_crates_client.toml");
+
         AppleCrateAPI.AppleCrateBuilder.registerVanilla();
         //call after mod compat so it can register new WoodTypes
         GeneralRegistry.prepareForRegistry(MODID, GeneralRegistry.BLOCKS, GeneralRegistry.ITEMS, GeneralRegistry.BLOCK_ENTITY_TYPES);
-
     }
 }

--- a/Forge/src/main/java/jackdaw/applecrates/client/ClientConfig.java
+++ b/Forge/src/main/java/jackdaw/applecrates/client/ClientConfig.java
@@ -1,0 +1,23 @@
+package jackdaw.applecrates.client;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public class ClientConfig {
+    public static final ForgeConfigSpec SPEC;
+    public static ForgeConfigSpec.EnumValue<CrateItemRendering> crateItemRendering;
+
+    static {
+        ForgeConfigSpec.Builder configBuilder = new ForgeConfigSpec.Builder();
+        setupConfig(configBuilder);
+        SPEC = configBuilder.build();
+    }
+
+    private static void setupConfig(ForgeConfigSpec.Builder builder) {
+        crateItemRendering = builder.defineEnum("crate_item_rendering", CrateItemRendering.THREE);
+    }
+
+    public static enum CrateItemRendering {
+        THREE,
+        MANY
+    }
+}

--- a/Forge/src/main/java/jackdaw/applecrates/client/besr/CrateBESR.java
+++ b/Forge/src/main/java/jackdaw/applecrates/client/besr/CrateBESR.java
@@ -57,8 +57,8 @@ public class CrateBESR implements BlockEntityRenderer<CrateBE> {
 
                 stack.translate(
                         (i % ITEMS_PER_ROW) * 0.25 - 0.25, // x or crate's left/right
-                        0.15f + ((float) (i / ITEMS_PER_ROW) / (float) MAX_RENDERED_ITEMS) * 2.0, //z or crate's up/down
-                        0.1f + (float) i * 0.025 //y or crate's higher/lower. In general, don't touch this value
+                        0.17f + ((int) (i / ITEMS_PER_ROW) / (float) MAX_RENDERED_ITEMS) * 2.0, //z or crate's up/down
+                        0.1f + ((int) (i / ITEMS_PER_ROW) % 2) * 0.025 + randX * 0.02 + (i % 2)*0.01 //y or crate's higher/lower. In general, don't touch this value
                 );
 
                 Minecraft.getInstance().getItemRenderer().renderStatic(
@@ -83,8 +83,4 @@ public class CrateBESR implements BlockEntityRenderer<CrateBE> {
         return new Vec3(d0, 0.0, d2);
     }
 
-    private int getRenderedItemCount(int itemCount, int countPerSale) {
-        float countPlusSale = itemCount + countPerSale;
-        return (int) (((countPlusSale * countPlusSale) / (float) (countPerSale * countPerSale)) - 1f);
-    }
 }

--- a/Forge/src/main/java/jackdaw/applecrates/container/CrateStackHandler.java
+++ b/Forge/src/main/java/jackdaw/applecrates/container/CrateStackHandler.java
@@ -1,15 +1,35 @@
 package jackdaw.applecrates.container;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.ItemStackHandler;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class CrateStackHandler extends ItemStackHandler {
 
     public static final String TAGSTOCK = "stocked";
 
+    private final Map<Item, Integer> itemCountCache = new HashMap<>();
+
     public CrateStackHandler() {
         super(30);
+    }
+
+    public int getCountOfItem(Item item) {
+        return this.itemCountCache.computeIfAbsent(item, $ -> {
+            int count = 0;
+            for (int i = 0; i < this.getSlots(); i++) {
+                var stack = this.getStackInSlot(i);
+                if (stack.is(item)) {
+                    count += stack.getCount();
+                }
+            }
+
+            return count;
+        });
     }
 
     public boolean updateStackInPaymentSlot(ItemStack payment, boolean isUnlimitedShop) {
@@ -33,5 +53,17 @@ public class CrateStackHandler extends ItemStackHandler {
         }
         setStackInSlot(29, prepXchange);
         return true;
+    }
+
+    @Override
+    protected void onContentsChanged(int slot) {
+        super.onContentsChanged(slot);
+        this.itemCountCache.clear();
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag nbt) {
+        super.deserializeNBT(nbt);
+        this.itemCountCache.clear();
     }
 }


### PR DESCRIPTION
# Motivation

See #9.

# Content

Currently, this PR makes crates render up to 9 items in rows of 3, depending on its fullness. One rendered item is equivalent to one selling stack, so if a crate sells 10 apples, then it will need to be full of 90 apples to look completely full.

It also adds a config, with the option to switch between new and old style rendering.